### PR TITLE
Fix getAllMemoryFromIda to return all sections instead of just one

### DIFF
--- a/apiscout/IdaTools.py
+++ b/apiscout/IdaTools.py
@@ -69,7 +69,7 @@ class IdaTools(object):
     def getAllMemoryFromIda(self):
         result = ""
         start = self.getBaseAddress()
-        end = idc.SegEnd(start)
+        end = self.getLastAddress()
         for ea in lrange(start, end):
             result += chr(idc.Byte(ea))
         return result


### PR DESCRIPTION
See https://github.com/danielplohmann/apiscout/issues/2