### PR TITLE
avoid logging.basicConfig when other loggers exist

### DIFF
--- a/apiscout/ApiScout.py
+++ b/apiscout/ApiScout.py
@@ -34,7 +34,9 @@ from .ImportTableLoader import ImportTableLoader
 from .ApiVector import ApiVector
 from .PeTools import PeTools
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+# Only do basicConfig if no handlers have been configured
+if len(logging._handlerList) == 0:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 LOG = logging.getLogger(__name__)
 
 

--- a/apiscout/ApiVector.py
+++ b/apiscout/ApiVector.py
@@ -32,8 +32,9 @@ import math
 from operator import itemgetter
 from itertools import groupby
 
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+# Only do basicConfig if no handlers have been configured
+if len(logging._handlerList) == 0:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 LOG = logging.getLogger(__name__)
 
 

--- a/apiscout/PeTools.py
+++ b/apiscout/PeTools.py
@@ -3,7 +3,8 @@ import struct
 
 from .utility import get_word
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+if len(logging._handlerList) == 0:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 LOG = logging.getLogger(__name__)
 
 class PeTools(object):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE') as f:
 
 setup(
     name='apiscout',
-    version='1.0.0',
+    version='1.0.1',
     description='Windows API recovery.',
     long_description=README,
     author='Daniel Plohmann',


### PR DESCRIPTION
This is a small change to avoid overwriting logging handlers/formatters that may already exist