### PR TITLE
adding function type information during naming of imports

### DIFF
--- a/ida_scout.py
+++ b/ida_scout.py
@@ -55,8 +55,9 @@ def main():
             updateResults(all_results, scout.crawl(binary))
         selected_apis = tools.formSelectResults(all_results)
         if selected_apis:
-            num_renamed, num_skipped = tools.applyApiNames(selected_apis)
-            print("Annotated %d APIs (%d skipped)." % (num_renamed, num_skipped))
+            tools.importTypeLibraries()
+            num_renamed, num_skipped, num_xrefs_adapted = tools.applyApiNames(selected_apis)
+            print("Annotated %d APIs and adapted %d Xrefs(%d skipped)." % (num_renamed, num_xrefs_adapted, num_skipped))
         else:
             print("No APIs selected for annotation, closing.")
 


### PR DESCRIPTION
In your talk in Bochum last week you said Apiscout is not yet setting the type information of the identified APIs in IDA. This PR should help. I tested it successfully with IDA 6.9 and 7.2

I'm not too happy by always importing the two Type Libraries (wdk8_um and mssdk_win7), but it helps IDA in identifying the types of the named Imports, and it is a prerequisite for setting the type information on the Xrefs.

Hope that helps. :)