### PR TITLE
Allow Python3 installation to grab the latest lief version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = ["numpy", "Pillow", "wheel"]
 
 if sys.version_info >= (3, 0):
     # py3
-    requirements.append("lief)
+    requirements.append("lief")
 else:
     # py2 - newer LIEF is Python3 only
     requirements.append("lief==0.9.0")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = ["numpy", "Pillow", "wheel"]
 
 if sys.version_info >= (3, 0):
     # py3
-    requirements.append("lief==0.10.1")
+    requirements.append("lief)
 else:
     # py2 - newer LIEF is Python3 only
     requirements.append("lief==0.9.0")


### PR DESCRIPTION
Hello!

Ran into an issue when installing apiscout on Debian Buster with Python 3.9.

Removing the version cap for lief allowed me to install apiscout without issue.