### PR TITLE
Add output support for the call/jmp referencing addresses in JSON_FILE mode

### DIFF
--- a/scout.py
+++ b/scout.py
@@ -63,7 +63,8 @@ def write_results_to_json(output_file, filtered_results):
                     "offset": api[0],
                     "apiAddress": api[1],
                     "dll": api[2].split('_')[0]+f"({api[4]} bit)",
-                    "api": api[3]
+                    "api": api[3],
+                    "references": sorted(api[7])
                     })
 
     with open(output_file, 'w') as f:


### PR DESCRIPTION
Hi Daniel, 

I use this tool to patch/rebuild IAT from a mapping PE dmp file. It works very well only that I need to find all `call/jmp xxxx` addresses **manually** to patch/replace the address  via LIEF libaray.

The core logic code is like:

```python
dInfos = 
[
    {
        "offset": 25312,
        "apiAddress": 1993408960,
        "dll": "advapi32.dll(32 bit)",
        "api": "RegSetValueExA",
        "references": [ # !!! apiscout lacks this information, so I need to find these addresses manually or by script
            9257,
            9294
        ]
    },
]

# Rebuild IAT entries
for info in dInfos: 
    lib_name = info['dll'].split('(')[0]
    entry_name = info['api']
    lib = binary.get_import(lib_name)
    # create new library if not exist
    if not lib:
        lib = binary.add_library(lib_name)
    entry = lib.get_entry(entry_name)
    # add new function entry if not exist
    if not entry:
        entry = lib.add_entry(entry_name)

# Fix IAT-related call reference
imagebase = binary.optional_header.imagebase
for info in dInfos:
    lib_name = info['dll'].split('(')[0]
    entry_name = info['api']
    # iat_addr_va: LIEF reassigned address
    iat_addr_va = imagebase + binary.predict_function_rva(lib_name, entry_name)
    for insn_va in info['references']:
        # print(f'{lib_name}!{entry_name} called by 0x{insn_va:x}: (insn) call 0x{iat_addr_va:x}')
        # Actually, the mnemonics of insn calling IAT include: CALL, JMP, etc.
        # Ref: https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/malware/impscan.py#L197-L219
        #
        # FF 15 dd cc bb aa    CALL 0xaabbccdd
        binary.patch_address(insn_va + 2, iat_addr_va, 4, binary.VA_TYPES.RVA)
```

As ApiScout has supplied the basic api-related context info already, why not add the xreference info as well to make it more convenient, suitable, and automated for such a scenario?

So I change it a little to fit my needs. **This PR only affects the JSON's output layout**, i.e., it adds an additional field named `references`(follow your convention, use RVA here) to holds all call/jmp instruction addresses.

> python scout.py /path/to/binary /path/to/db -o iats.json

```json
[
    {
        "offset": 25312,
        "apiAddress": 1993408960,
        "dll": "advapi32.dll(32 bit)",
        "api": "RegSetValueExA",
        "references": [
            9257,
            9294
        ]
    },
    {
        "offset": 25316,
        "apiAddress": 1993402960,
        "dll": "advapi32.dll(32 bit)",
        "api": "RegQueryValueExA",
        "references": [
            9350,
            9428
        ]
    },
   ...snip...
]
```

The default console layout and rendered result are consistent.

After that, we can import this JSON file directly and patch the binary data.